### PR TITLE
ability to toggle viewing of implicit functions in outline view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-boxlang",
-    "version": "0.9.15",
+    "version": "1.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-boxlang",
-            "version": "0.9.15",
+            "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
                 "async_hooks": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -297,6 +297,12 @@
                     "default": true,
                     "scope": "resource"
                 },
+                "cfml.outline.showImplicitFunctions": {
+                    "type": "boolean",
+                    "description": "Whether to show implicit Functions in Outline View.",
+                    "default": true,
+                    "scope": "resource"
+                },
                 "cfml.suggest.enable": {
                     "type": "boolean",
                     "description": "Whether completion help is enabled.",

--- a/src/entities/component.ts
+++ b/src/entities/component.ts
@@ -359,7 +359,7 @@ export function parseComponent(documentStateContext: DocumentStateContext): Comp
   });
 
   // Implicit functions
-  if (component.accessors) {
+  if (component.accessors && showImplicitFunctions) {
     component.properties.forEach((prop: Property) => {
       // getters
       if (typeof prop.getter === "undefined" || prop.getter) {

--- a/src/entities/component.ts
+++ b/src/entities/component.ts
@@ -1,7 +1,7 @@
 //import findup from "findup-sync";
 import * as fs from "fs";
 import * as path from "path";
-import { Position, Range, TextDocument, Uri } from "vscode";
+import { Position, Range, TextDocument, Uri, workspace } from "vscode";
 import * as cachedEntities from "../features/cachedEntities";
 import { getComponent, hasComponent } from "../features/cachedEntities";
 import { MySet } from "../utils/collections";
@@ -60,6 +60,9 @@ export const objectReferencePatterns: ReferencePattern[] = [
   },
 ];
 // TODO: variableReferencePatterns
+
+const cfmlOutlineSettings = workspace.getConfiguration("cfml.outline");
+const showImplicitFunctions = cfmlOutlineSettings.get<boolean>("showImplicitFunctions", true);
 
 const componentAttributeNames: MySet<string> = new MySet([
   "accessors",


### PR DESCRIPTION
Listing all of the implicit get/set functions in Outline View can be useless noise. This creates a setting to toggle those on/off.