### PR TITLE
Add missing schema definitions for new bxformat settings

### DIFF
--- a/resources/schemas/bxformat.schema.json
+++ b/resources/schemas/bxformat.schema.json
@@ -439,6 +439,11 @@
 			"type": "object",
 			"description": "Configuration for template/tag-based code formatting",
 			"properties": {
+				"enabled": {
+					"type": "boolean",
+					"default": false,
+					"description": "Enable or disable template/tag-based code formatting (.bxm or .cfm files)."
+				},
 				"component_prefix": {
 					"type": "string",
 					"default": "bx",
@@ -513,6 +518,13 @@
 					"maximum": 5,
 					"description": "Number of blank lines between class members"
 				},
+                "property_spacing":{
+					"type": "integer",
+					"default": 1,
+					"minimum": 0,
+					"maximum": 5,
+					"description": "Number of blank lines between property members"
+                },
 				"property_order": {
 					"type": "string",
 					"default": "preserve",


### PR DESCRIPTION
<img width="893" height="1187" alt="image" src="https://github.com/user-attachments/assets/63fb1ff3-3ab8-475f-873f-33d6db5c02a5" />
